### PR TITLE
Complete move to Vaadin v8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>wizards-for-vaadin-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<name>Wizards for Vaadin Parent</name>
 
 	<modules>

--- a/wizards-for-vaadin-demo/pom.xml
+++ b/wizards-for-vaadin-demo/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.0.4</vaadin.version>
+		<vaadin.version>8.0.5</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 	</properties>
 

--- a/wizards-for-vaadin-demo/pom.xml
+++ b/wizards-for-vaadin-demo/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>wizards-for-vaadin-demo</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>war</packaging>
 	<name>Wizards for Vaadin Demo</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.0.0</vaadin.version>
+		<vaadin.version>8.0.4</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 	</properties>
 
@@ -52,12 +52,12 @@
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-compatibility-client-compiled</artifactId>
+			<artifactId>vaadin-client-compiled</artifactId>
 			<version>${vaadin.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-compatibility-themes</artifactId>
+			<artifactId>vaadin-themes</artifactId>
 			<version>${vaadin.version}</version>
 		</dependency>
 		<dependency>

--- a/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/IntroStep.java
+++ b/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/IntroStep.java
@@ -1,11 +1,11 @@
 package org.vaadin.teemu.wizards;
 
 import com.vaadin.server.ThemeResource;
-import com.vaadin.v7.shared.ui.label.ContentMode;
+import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Embedded;
-import com.vaadin.v7.ui.Label;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
 
 public class IntroStep implements WizardStep {
 

--- a/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/LastStep.java
+++ b/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/LastStep.java
@@ -2,14 +2,14 @@ package org.vaadin.teemu.wizards;
 
 import java.util.Date;
 
-import com.vaadin.v7.shared.ui.label.ContentMode;
+import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
-import com.vaadin.v7.ui.CheckBox;
+import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.Component;
-import com.vaadin.v7.ui.Label;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.Notification;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.VerticalLayout;
 
 public class LastStep implements WizardStep {
 

--- a/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/ListenStep.java
+++ b/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/ListenStep.java
@@ -1,11 +1,11 @@
 package org.vaadin.teemu.wizards;
 
 import com.vaadin.server.ThemeResource;
-import com.vaadin.v7.shared.ui.label.ContentMode;
+import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Embedded;
-import com.vaadin.v7.ui.Label;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
 
 public class ListenStep implements WizardStep {
 

--- a/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/SetupStep.java
+++ b/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/SetupStep.java
@@ -1,9 +1,9 @@
 package org.vaadin.teemu.wizards;
 
-import com.vaadin.v7.shared.ui.label.ContentMode;
+import com.vaadin.shared.ui.ContentMode;
 import com.vaadin.ui.Component;
-import com.vaadin.v7.ui.Label;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
 
 public class SetupStep implements WizardStep {
 

--- a/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/WizardsDemoApplication.java
+++ b/wizards-for-vaadin-demo/src/main/java/org/vaadin/teemu/wizards/WizardsDemoApplication.java
@@ -15,7 +15,7 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.UI;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.VerticalLayout;
 
 /**
  * Demo application for the <a

--- a/wizards-for-vaadin-demo/src/main/webapp/WEB-INF/web.xml
+++ b/wizards-for-vaadin-demo/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
 		</init-param>
         <init-param>
             <param-name>widgetset</param-name>
-            <param-value>com.vaadin.v7.Vaadin7WidgetSet</param-value>
+            <param-value>com.vaadin.DefaultWidgetSet</param-value>
         </init-param>
 	</servlet>
 

--- a/wizards-for-vaadin/pom.xml
+++ b/wizards-for-vaadin/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.0.4</vaadin.version>
+		<vaadin.version>8.0.5</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->

--- a/wizards-for-vaadin/pom.xml
+++ b/wizards-for-vaadin/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>wizards-for-vaadin</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<packaging>jar</packaging>
 	<name>Wizards for Vaadin</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.0.0</vaadin.version>
+		<vaadin.version>8.0.4</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->
@@ -62,12 +62,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-compatibility-server</artifactId>
+			<artifactId>vaadin-server</artifactId>
 			<version>${vaadin.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-compatibility-client</artifactId>
+			<artifactId>vaadin-client</artifactId>
 			<version>${vaadin.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/wizards-for-vaadin/src/main/java/org/vaadin/teemu/wizards/Wizard.java
+++ b/wizards-for-vaadin/src/main/java/org/vaadin/teemu/wizards/Wizard.java
@@ -21,9 +21,9 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomComponent;
-import com.vaadin.v7.ui.HorizontalLayout;
+import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Panel;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.VerticalLayout;
 
 /**
  * Component for displaying multi-step wizard style user interface.

--- a/wizards-for-vaadin/src/main/java/org/vaadin/teemu/wizards/WizardProgressBar.java
+++ b/wizards-for-vaadin/src/main/java/org/vaadin/teemu/wizards/WizardProgressBar.java
@@ -10,10 +10,10 @@ import org.vaadin.teemu.wizards.event.WizardStepSetChangedEvent;
 
 import com.vaadin.annotations.StyleSheet;
 import com.vaadin.ui.CustomComponent;
-import com.vaadin.v7.ui.HorizontalLayout;
-import com.vaadin.v7.ui.Label;
-import com.vaadin.v7.ui.ProgressBar;
-import com.vaadin.v7.ui.VerticalLayout;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.ProgressBar;
+import com.vaadin.ui.VerticalLayout;
 
 /**
  * Displays a progress bar for a {@link Wizard}.


### PR DESCRIPTION
- Replaced all references to vaadin.v7 components with v8 equivallent, 
- Replaced v7 compability layer with v8 layer
- Switch demo to DefaultWidgetset
- Bumped version to 2.0.1
- Use Vaadin v8.0.5